### PR TITLE
Option to override what we send to peers as a host.

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -37,9 +37,12 @@ class KafkaProvides(RelationBase):
     # call this method when passed into methods decorated with
     # @when('{relation}.available')
     # to configure the relation data
-    def send_port(self, port):
+    def send_connection(self, port, host=None):
         conv = self.conversation()
         conv.set_remote('port', port)
+        conv.set_remote('host', host)
+
+    send_port = send_connection
 
     def send_zookeepers(self, zookeepers):
         """

--- a/requires.py
+++ b/requires.py
@@ -42,9 +42,11 @@ class KafkaRequires(RelationBase):
         kafkas = []
         for conv in self.conversations():
             port = conv.get_remote('port')
+            host = conv.get_remote('host') or conv.get_remote(
+                'private-address')
             if port:
                 kafkas.append({
-                    'host': conv.get_remote('private-address'),
+                    'host': host,
                     'port': port
                 })
         return kafkas


### PR DESCRIPTION
Normally, private-address is fine. There are circumstances, such as when
we are binding to a specific network interface, that we may want to
override this, however.

@juju-solutions/bigdata 
